### PR TITLE
Updated projects to .NET 8.0

### DIFF
--- a/OmsiExtensionsCLI/OmsiExtensionsCLI.csproj
+++ b/OmsiExtensionsCLI/OmsiExtensionsCLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <PlatformTarget>x86</PlatformTarget>
     <Platforms>x86</Platforms>
 	<ApplicationIcon>favicon.ico</ApplicationIcon>

--- a/OmsiExtensionsUI/OmsiExtensionsUI.csproj
+++ b/OmsiExtensionsUI/OmsiExtensionsUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
 	<Platforms>x86</Platforms>
   </PropertyGroup>

--- a/OmsiHook/OmsiHook.csproj
+++ b/OmsiHook/OmsiHook.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0-windows</TargetFramework>
+		<TargetFramework>net8.0-windows</TargetFramework>
 		<Authors>Thomas Mathieson et al</Authors>
 		<Copyright>Copyright Thomas Mathieson 2022-2024 all rights reserved</Copyright>
 		<PackageProjectUrl>https://github.com/space928/Omsi-Extensions</PackageProjectUrl>
@@ -62,15 +62,10 @@
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>
-		<!--<None Include="..\OmsiHook\bin\x86\$(_ConfigurationNormalized)\$(TargetFramework)\OmsiHook.deps.json" Link="OmsiHook.deps.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<Pack>True</Pack>
-			<PackagePath>\lib\net6.0-windows7.0</PackagePath>
-		</None>-->
 		<None Include="..\$(_ConfigurationNormalized)\OmsiHookInvoker.dll" Link="OmsiHookInvoker.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<Pack>True</Pack>
-			<PackagePath>\lib\net6.0-windows7.0</PackagePath>
+			<PackagePath>\lib\net8.0</PackagePath>
 		</None>
 		<None Include="..\OmsiHookRPCPlugin\bin\x86\$(_ConfigurationNormalized)\$(TargetFramework)\OmsiHookRPCPlugin.dll" Link="OmsiHookRPCPlugin.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -85,17 +80,17 @@
 		<None Include="..\OmsiHookRPCPlugin\bin\x86\$(_ConfigurationNormalized)\$(TargetFramework)\OmsiHookRPCPlugin.runtimeconfig.json" Link="OmsiHookRPCPlugin.runtimeconfig.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<Pack>True</Pack>
-			<PackagePath>\lib\net6.0-windows7.0</PackagePath>
+			<PackagePath>\lib\net8.0</PackagePath>
 		</None>
 		<None Include="..\OmsiHookRPCPlugin\bin\x86\$(_ConfigurationNormalized)\$(TargetFramework)\OmsiHookRPCPluginNE.dll" Link="OmsiHookRPCPluginNE.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<Pack>True</Pack>
-			<PackagePath>\lib\net6.0-windows7.0</PackagePath>
+			<PackagePath>\lib\net8.0</PackagePath>
 		</None>
 		<None Include="..\OmsiHookRPCPlugin\bin\x86\$(_ConfigurationNormalized)\$(TargetFramework)\OmsiHookRPCPlugin.opl" Link="OmsiHookRPCPlugin.opl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<Pack>True</Pack>
-			<PackagePath>\lib\net6.0-windows7.0</PackagePath>
+			<PackagePath>\lib\net8.0</PackagePath>
 		</None>
 	</ItemGroup>
 	
@@ -118,6 +113,11 @@
 		  <Private>True</Private>
 		  <CopyLocalSatelliteAssemblies>True</CopyLocalSatelliteAssemblies>
 		</ProjectReference>
+		<TargetFramework>net8.0-windows</TargetFramework>
+		<AssemblyVersion>2.5.3.1</AssemblyVersion>
+		<FileVersion>2.5.3.1</FileVersion>
+		<Version>2.5.3</Version>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 	</ItemGroup>
 
 	<!--Hack to fix docfx build bug... For some reason sometimes docfx tries to load the wrong version of System.Memory.dll; as 

--- a/OmsiHookPlugin/OmsiHookPlugin.csproj
+++ b/OmsiHookPlugin/OmsiHookPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Platforms>x86</Platforms>
   </PropertyGroup>
   <PropertyGroup>

--- a/OmsiHookRPCPlugin/OmsiHookRPCPlugin.csproj
+++ b/OmsiHookRPCPlugin/OmsiHookRPCPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
   <PropertyGroup>

--- a/_OmsiHookExamples/BasicCLI/BasicCLI.csproj
+++ b/_OmsiHookExamples/BasicCLI/BasicCLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>x86</Platforms>

--- a/_OmsiHookExamples/ClickablePlaneDemo/ClickablePlaneDemo.csproj
+++ b/_OmsiHookExamples/ClickablePlaneDemo/ClickablePlaneDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>ClickablePlaneDemo.Program</StartupObject>

--- a/_OmsiHookExamples/EventSample/EventSample.csproj
+++ b/_OmsiHookExamples/EventSample/EventSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>EventSample.Program</StartupObject>

--- a/_OmsiHookExamples/TriggersSample/TriggersSample.csproj
+++ b/_OmsiHookExamples/TriggersSample/TriggersSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>TriggersSample.Program</StartupObject>

--- a/_OmsiHookExamples/VideoDemo/VideoDemo.csproj
+++ b/_OmsiHookExamples/VideoDemo/VideoDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>VideoDemo.Program</StartupObject>


### PR DESCRIPTION
### Updated projects to .NET 8.0:
- Updated all projects to .NET 8.0 (Windows)

### Note
 Maybe it would be better to set project framework to .NET Standard 2.1 so users can choose which .NET framework they will use for their project.