### PR TITLE
Document that Lenkhebel is not a real steering value on road vehicles

### DIFF
--- a/OmsiHook/WrappedOmsiClasses/OmsiMovingMapObjInst.cs
+++ b/OmsiHook/WrappedOmsiClasses/OmsiMovingMapObjInst.cs
@@ -31,8 +31,19 @@
             set => Memory.WriteMemory(Address + 0x264, value);
         }
         /// <summary>
-        /// Steering arm
+        /// Steering arm.
         /// </summary>
+        /// <remarks>
+        /// This offset does not appear to hold a steering value on OMSI 2.3 road vehicles.
+        /// Disassembling <c>Omsi.exe</c> 2.3 shows every real access to
+        /// <c>TRoadVehicle</c>/<c>TRoadVehicleInst</c>+0x268 as an array-typed field, not a
+        /// float; writing here has no visible effect on steering. For road vehicles, the value
+        /// that actually drives steering (read by <c>TRoadVehicleInst_CalcFree</c>'s per-axle
+        /// Ackermann geometry and written by the keyboard steering-left/steering-right key
+        /// handlers) is <see cref="OmsiRoadVehicleInst.Inv_LenkRadius"/> instead. Left as-is
+        /// rather than changed/removed in case something else already depends on this offset for
+        /// a different, non-vehicle <see cref="OmsiMovingMapObjInst"/> subtype.
+        /// </remarks>
         public float Lenkhebel
         {
             get => Memory.ReadMemory<float>(Address + 0x268);

--- a/OmsiHook/WrappedOmsiClasses/OmsiRoadVehicleInst.cs
+++ b/OmsiHook/WrappedOmsiClasses/OmsiRoadVehicleInst.cs
@@ -65,6 +65,16 @@ namespace OmsiHook
             get => Memory.ReadMemory<D3DVector>(Address + 0x72d);
             set => Memory.WriteMemory(Address + 0x72d, value);
         }
+        /// <summary>
+        /// Inverse turning radius (Delphi field name <c>inv_lenkradius</c>) - the value that
+        /// actually drives a road vehicle's steering, not <see cref="OmsiMovingMapObjInst.Lenkhebel"/>
+        /// (see that property's remarks). Signed, bounded to the vehicle's own
+        /// <c>+-RoadVehicle.inv_min_radius</c>: 0 is straight ahead, positive/negative is left/right
+        /// lock depending on sign convention. Confirmed by disassembling <c>Omsi.exe</c> 2.3:
+        /// read every tick by <c>TRoadVehicleInst_CalcFree</c>'s per-axle Ackermann steering-angle
+        /// calculation, and directly ramped by the keyboard steering-left/steering-right key
+        /// handlers via add/subtract-then-clamp each frame the key is held.
+        /// </summary>
         public float Inv_LenkRadius
         {
             get => Memory.ReadMemory<float>(Address + 0x73c);


### PR DESCRIPTION
Disassembling Omsi.exe shows every real access to TRoadVehicle/TRoadVehicleInst+0x268 (Lenkhebel's offset) as an array-typed field, not a float - writing here has no effect on steering. The value that actually drives steering is OmsiRoadVehicleInst.Inv_LenkRadius (+0x73c), confirmed both as the input to TRoadVehicleInst_CalcFree's per-axle Ackermann geometry and as what the keyboard steering-left/steering-right key handlers directly ramp each frame. Inv_LenkRadius was already correctly wrapped here, just undocumented, so this only adds doc comments cross- referencing the two - Lenkhebel is left unchanged in case some other OmsiMovingMapObjInst subtype genuinely uses that offset.